### PR TITLE
feat: custom pace input for accurate time estimates

### DIFF
--- a/api/generate-route.py
+++ b/api/generate-route.py
@@ -108,8 +108,9 @@ class handler(BaseHTTPRequestHandler):
                     f"&travelmode=walking"
                 )
 
-            # Calculate estimated time (15 min/mile)
-            estimated_time_minutes = int(distance_miles * 15)
+            # Calculate estimated time using user-provided pace
+            pace_min_per_mile = float(data.get('pace_min_per_mile', 10))
+            estimated_time_minutes = int(distance_miles * pace_min_per_mile)
 
             # Build response
             response = {

--- a/index.html
+++ b/index.html
@@ -93,6 +93,26 @@
             </div>
           </div>
 
+          <!-- Pace Input -->
+          <div>
+            <label for="pace-select" class="block text-sm font-medium text-gray-700 mb-2">
+              Pace
+            </label>
+            <div class="flex items-center gap-2">
+              <select id="pace-select" class="border border-gray-300 rounded-lg px-3 py-2 text-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-500/10">
+                <option value="6">6 min/mi</option>
+                <option value="7">7 min/mi</option>
+                <option value="8">8 min/mi</option>
+                <option value="9">9 min/mi</option>
+                <option value="10" selected>10 min/mi</option>
+                <option value="11">11 min/mi</option>
+                <option value="12">12 min/mi</option>
+                <option value="13">13 min/mi</option>
+                <option value="15">15+ min/mi</option>
+              </select>
+            </div>
+          </div>
+
           <!-- Preferences -->
           <div class="space-y-3">
             <label class="block text-sm font-medium text-gray-700">

--- a/src/main.ts
+++ b/src/main.ts
@@ -45,6 +45,7 @@ const copyLinkBtn = document.getElementById('copy-link-btn') as HTMLButtonElemen
 const shareBtn = document.getElementById('share-btn') as HTMLButtonElement;
 const editSelectionsBtn = document.getElementById('edit-selections-btn') as HTMLButtonElement;
 const startOverBtn = document.getElementById('start-over-btn') as HTMLButtonElement;
+const paceSelect = document.getElementById('pace-select') as HTMLSelectElement;
 const toggleMapSizeBtn = document.getElementById('toggle-map-size') as HTMLButtonElement;
 const loading = document.getElementById('loading') as HTMLDivElement;
 const initLoader = document.getElementById('init-loader') as HTMLDivElement;
@@ -281,6 +282,12 @@ if (toggleMapSizeBtn) {
     }
   });
 }
+
+// Pace select — load persisted value and save on change
+paceSelect.value = localStorage.getItem('pace_min_per_mile') || '10';
+paceSelect.addEventListener('change', () => {
+  localStorage.setItem('pace_min_per_mile', paceSelect.value);
+});
 
 // Distance select handler
 distanceSelect.addEventListener('change', () => {
@@ -519,6 +526,7 @@ generateRouteBtn.addEventListener('click', async () => {
       start: state.location,
       selected_places: selectedPlaces,
       preferences: state.preferences,
+      pace_min_per_mile: parseInt(paceSelect.value),
     });
 
     state.generatedRoute = response;

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,6 +37,7 @@ export interface RouteRequest {
   start: Location;
   selected_places: Place[];
   preferences?: Preferences;
+  pace_min_per_mile?: number;
 }
 
 export interface RouteResponse {


### PR DESCRIPTION
## Summary
- Add pace dropdown (6–15+ min/mile, default 10) to the route form
- Pass `pace_min_per_mile` to the backend route generation API
- Replace hardcoded 15 min/mile with user-provided pace
- Persist pace selection in localStorage across sessions

Closes #3