### PR TITLE
feat: shareable route URLs via URL state encoding

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { RouteMap } from './map';
 import { suggestPlaces, generateRoute } from './api';
 import { loadGoogleMapsAPI } from './google-maps-loader';
 import type { AppState, Place, Preferences } from './types';
+import { encodeRoute, decodeRoute } from './route-serializer';
 
 // Analytics tracking
 function track(event: string, properties?: Record<string, any>): void {
@@ -216,6 +217,41 @@ async function initAutocomplete(): Promise<void> {
         updateProgress('location');
       }
     );
+
+    // Load route from URL param if present
+    const urlParams = new URLSearchParams(window.location.search);
+    const routeParam = urlParams.get('r');
+    if (routeParam) {
+      const restored = decodeRoute(routeParam);
+      if (restored) {
+        state.location = restored.location;
+        state.distance = restored.distanceMiles;
+        state.preferences = restored.preferences;
+        state.suggestedPlaces = restored.places;
+        state.selectedPlaceIds = new Set(restored.selectedPlaceIds);
+
+        // Update distance select
+        const distValues = ['3', '5', '7', '10', '13.1', '15', '26.2'];
+        if (distValues.includes(String(restored.distanceMiles))) {
+          distanceSelect.value = String(restored.distanceMiles);
+        } else {
+          distanceSelect.value = 'custom';
+          distanceCustom.classList.remove('hidden');
+          distanceCustom.value = String(restored.distanceMiles);
+        }
+
+        // Update preference checkboxes
+        if (restored.preferences.prefer_parks) { prefParks.checked = true; document.querySelector('[data-pref="parks"]')?.classList.add('active'); }
+        if (restored.preferences.water_stops) { prefWater.checked = true; document.querySelector('[data-pref="water"]')?.classList.add('active'); }
+        if (restored.preferences.urban_explorer) { prefUrban.checked = true; document.querySelector('[data-pref="urban"]')?.classList.add('active'); }
+        if (restored.preferences.trail_runner) { prefTrail.checked = true; document.querySelector('[data-pref="trail"]')?.classList.add('active'); }
+
+        findPlacesBtn.disabled = false;
+        displayPlaces();
+        mapSection.classList.remove('hidden');
+        updateProgress('places');
+      }
+    }
 
     // Hide initial loader
     if (initLoader) {
@@ -584,15 +620,21 @@ openMapsBtn.addEventListener('click', () => {
   track('maps_opened');
 });
 copyLinkBtn.addEventListener('click', async () => {
-  if (!state.generatedRoute) return;
+  if (!state.generatedRoute || !state.location) return;
 
   try {
-    await navigator.clipboard.writeText(state.generatedRoute.google_maps_url);
+    const encoded = encodeRoute({
+      location: state.location,
+      distanceMiles: state.distance,
+      preferences: state.preferences,
+      selectedPlaceIds: Array.from(state.selectedPlaceIds),
+      places: state.suggestedPlaces,
+    });
+    const shareUrl = `${window.location.origin}${window.location.pathname}?r=${encoded}`;
+    await navigator.clipboard.writeText(shareUrl);
     track('link_copied');
     copyLinkBtn.textContent = 'Copied!';
-    setTimeout(() => {
-      copyLinkBtn.textContent = 'Copy Link';
-    }, 2000);
+    setTimeout(() => { copyLinkBtn.textContent = 'Copy Link'; }, 2000);
   } catch (error) {
     showError('Failed to copy link');
   }

--- a/src/route-serializer.ts
+++ b/src/route-serializer.ts
@@ -1,0 +1,51 @@
+import type { Location, Place, Preferences } from './types';
+
+export interface RouteState {
+  location: Location;
+  distanceMiles: number;
+  preferences: Preferences;
+  selectedPlaceIds: string[];
+  places: Place[];
+}
+
+export function encodeRoute(state: RouteState): string {
+  const compact = {
+    l: state.location,
+    d: state.distanceMiles,
+    p: state.preferences,
+    s: state.selectedPlaceIds,
+    pl: state.places.map(p => ({
+      i: p.id,
+      n: p.name,
+      t: p.types,
+      lo: p.location,
+      r: p.rating,
+      ds: p.distance_from_start,
+    })),
+  };
+  return btoa(encodeURIComponent(JSON.stringify(compact)));
+}
+
+export function decodeRoute(param: string): RouteState | null {
+  try {
+    const json = decodeURIComponent(atob(param));
+    const compact = JSON.parse(json);
+    return {
+      location: compact.l,
+      distanceMiles: compact.d,
+      preferences: compact.p || {},
+      selectedPlaceIds: compact.s || [],
+      places: (compact.pl || []).map((p: any) => ({
+        id: p.i,
+        name: p.n,
+        types: p.t,
+        location: p.lo,
+        rating: p.r,
+        distance_from_start: p.ds,
+        photo_url: undefined,
+      })),
+    };
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- Encode full route state (location, preferences, places, selections) into a compact base64 URL param `?r=`
- 'Copy Link' now copies an app URL that auto-restores the route on load
- No backend or database required — pure URL state
- Works with any URL shortener

Closes #8