### PR TITLE
feat: multiple route alternatives (Iconic, Scenic, Efficient)

### DIFF
--- a/api/suggest-places.py
+++ b/api/suggest-places.py
@@ -19,6 +19,7 @@ class handler(BaseHTTPRequestHandler):
             lng = float(location.get('lng'))
             distance_miles = float(params.get('distance_miles', 3))
             preferences = params.get('preferences', {})
+            strategy = params.get('strategy', 'iconic')  # 'iconic' | 'scenic' | 'efficient'
 
             # Initialize Google Maps client
             api_key = os.environ.get('GOOGLE_PLACES_API_KEY')
@@ -81,7 +82,7 @@ class handler(BaseHTTPRequestHandler):
                 if place.get('business_status') == 'CLOSED_PERMANENTLY':
                     continue
 
-                score = calculate_score(place, preferences, lat, lng, radius_meters, max_reviews)
+                score = calculate_score(place, preferences, lat, lng, radius_meters, max_reviews, strategy)
 
                 # Down-rank currently closed places
                 opening_hours = place.get('opening_hours', {})
@@ -179,7 +180,7 @@ class handler(BaseHTTPRequestHandler):
         self.send_header('Access-Control-Allow-Headers', 'Content-Type')
         self.end_headers()
 
-def calculate_score(place, preferences, start_lat, start_lng, max_radius, max_reviews=10000):
+def calculate_score(place, preferences, start_lat, start_lng, max_radius, max_reviews=10000, strategy='iconic'):
     """Calculate score for a place based on type and preferences"""
     rating = place.get('rating', 3.0)
     user_ratings_total = place.get('user_ratings_total', 1)
@@ -235,6 +236,25 @@ def calculate_score(place, preferences, start_lat, start_lng, max_radius, max_re
             score *= 2.5
         elif any(t in types for t in ['museum', 'art_gallery', 'tourist_attraction', 'landmark']):
             score *= 0.3
+
+    # Strategy-specific scoring
+    if strategy == 'scenic':
+        if any(t in types for t in ['park', 'natural_feature', 'hiking_area', 'nature_preserve']):
+            score *= 4.0
+        elif 'waterfront' in types or 'beach' in types:
+            score *= 4.0
+        if any(t in types for t in ['tourist_attraction', 'landmark', 'monument']):
+            score *= 0.5
+    elif strategy == 'efficient':
+        # Efficient: minimize detour — heavily penalize places far from direct path
+        # Use a tighter distance factor (0.7 instead of 0.3)
+        location = place.get('geometry', {}).get('location', {})
+        distance = calculate_distance(start_lat, start_lng, location.get('lat'), location.get('lng'))
+        distance_meters = distance * 1609.34
+        if max_radius > 0:
+            detour_penalty = max(0.1, 1 - (distance_meters / max_radius) * 0.7)
+            score *= detour_penalty
+    # iconic: keep existing scoring (no changes)
 
     # FUTURE EXTENSION POINT:
     # When OpenStreetMap integration is added, inject OSM trail scores here.

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { RouteMap } from './map';
 import { suggestPlaces, generateRoute } from './api';
 import { loadGoogleMapsAPI } from './google-maps-loader';
 import { generateGPX, downloadGPX } from './gpx-export';
-import type { AppState, Place, Preferences } from './types';
+import type { AppState, Place, Preferences, RouteStrategy } from './types';
 import { encodeRoute, decodeRoute } from './route-serializer';
 
 // Analytics tracking
@@ -21,6 +21,8 @@ const state: AppState = {
   suggestedPlaces: [],
   selectedPlaceIds: new Set(),
   generatedRoute: null,
+  routeAlternatives: {},
+  activeStrategy: 'iconic',
 };
 
 // Initialize map
@@ -569,6 +571,10 @@ generateRouteBtn.addEventListener('click', async () => {
 
     state.generatedRoute = response;
 
+    // Cache current strategy result
+    state.routeAlternatives['iconic'] = { places: [...selectedPlaces], route: response };
+    state.activeStrategy = 'iconic';
+
     track('route_generated', {
       num_places: selectedPlaces.length,
       distance_requested: state.distance,
@@ -583,6 +589,36 @@ generateRouteBtn.addEventListener('click', async () => {
 
     // Display route summary
     displayRouteSummary();
+
+    // Fire parallel requests for other strategies (silently, no loading state)
+    const otherStrategies: RouteStrategy[] = ['scenic', 'efficient'];
+    Promise.all(
+      otherStrategies.map(async (strategy) => {
+        try {
+          const altPlacesResponse = await suggestPlaces({
+            location: state.location!,
+            distance_miles: state.distance,
+            preferences: state.preferences,
+            strategy,
+          });
+          const numToSelect = Math.min(state.selectedPlaceIds.size, altPlacesResponse.places.length);
+          const altSelected = altPlacesResponse.places.slice(0, numToSelect);
+          const altRoute = await generateRoute({
+            start: state.location!,
+            selected_places: altSelected,
+            preferences: state.preferences,
+          });
+          state.routeAlternatives[strategy] = { places: altSelected, route: altRoute };
+          // Update tab if currently viewing this strategy
+          if (state.activeStrategy === strategy) {
+            state.generatedRoute = altRoute;
+            displayRouteSummary();
+          }
+        } catch {
+          // Silent failure for alternatives
+        }
+      })
+    );
 
     routeSection.classList.remove('hidden');
     placesSection.classList.add('hidden');
@@ -662,7 +698,34 @@ function displayRouteSummary(): void {
 
   const elevationHTML = renderElevationChart(state.generatedRoute.elevation_profile || []);
 
+  const strategyLabels: Record<string, string> = {
+    iconic: 'Iconic',
+    scenic: 'Scenic',
+    efficient: 'Efficient',
+  };
+  const strategyDescriptions: Record<string, string> = {
+    iconic: 'Top-rated places',
+    scenic: 'Parks & nature',
+    efficient: 'Shortest detour',
+  };
+
+  const tabs = Object.entries(strategyLabels).map(([key, label]) => {
+    const isActive = key === state.activeStrategy;
+    const hasData = key === 'iconic' || !!state.routeAlternatives[key]?.route;
+    return `
+      <button class="strategy-tab px-4 py-2 text-sm font-medium rounded-lg transition-colors ${
+        isActive ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+      } ${!hasData ? 'opacity-50' : ''}" data-strategy="${key}" ${!hasData ? 'disabled' : ''}>
+        ${label}
+        <span class="block text-xs font-normal opacity-75">${strategyDescriptions[key]}</span>
+      </button>
+    `;
+  }).join('');
+
   routeSummary.innerHTML = `
+    <div class="flex gap-2 mb-4">
+      ${tabs}
+    </div>
     <p class="text-lg mb-2">
       <strong>${distance_miles} mile${distance_miles !== 1 ? 's' : ''}</strong>
       visiting ${optimized_order.length} place${optimized_order.length !== 1 ? 's' : ''}
@@ -673,6 +736,20 @@ function displayRouteSummary(): void {
   `;
 
   openMapsBtn.href = google_maps_url;
+
+  // Wire up tab clicks
+  routeSummary.querySelectorAll('.strategy-tab').forEach(tab => {
+    tab.addEventListener('click', () => {
+      const strategy = (tab as HTMLElement).dataset.strategy as RouteStrategy;
+      const alt = state.routeAlternatives[strategy];
+      if (alt?.route) {
+        state.activeStrategy = strategy;
+        state.generatedRoute = alt.route;
+        displayRouteSummary();
+        routeMap.showRoute(state.location!, alt.route.optimized_order.map(p => p.location));
+      }
+    });
+  });
 }
 
 // Route action handlers
@@ -767,6 +844,8 @@ startOverBtn.addEventListener('click', () => {
   state.suggestedPlaces = [];
   state.selectedPlaceIds.clear();
   state.generatedRoute = null;
+  state.routeAlternatives = {};
+  state.activeStrategy = 'iconic';
 
   findPlacesBtn.disabled = true;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,10 +23,13 @@ export interface Preferences {
   trail_runner?: boolean;
 }
 
+export type RouteStrategy = 'iconic' | 'scenic' | 'efficient';
+
 export interface SuggestPlacesRequest {
   location: Location;
   distance_miles: number;
   preferences?: Preferences;
+  strategy?: RouteStrategy;
 }
 
 export interface SuggestPlacesResponse {
@@ -61,4 +64,6 @@ export interface AppState {
   suggestedPlaces: Place[];
   selectedPlaceIds: Set<string>;
   generatedRoute: RouteResponse | null;
+  routeAlternatives: Record<string, { places: Place[]; route: RouteResponse | null }>;
+  activeStrategy: RouteStrategy;
 }


### PR DESCRIPTION
## Summary
- Add `strategy` param to `/api/suggest-places` with Iconic/Scenic/Efficient scoring modes
- Scenic: 4x multiplier for parks/nature, 0.5x for landmarks
- Efficient: additional distance penalty to minimize detour
- Frontend silently fetches all 3 strategies in parallel after initial route generation
- Tab UI on Route Summary for instant strategy switching (no additional API calls)

Closes #9