### PR TITLE
feat: Open Now filter chip

### DIFF
--- a/api/suggest-places.py
+++ b/api/suggest-places.py
@@ -74,6 +74,16 @@ class handler(BaseHTTPRequestHandler):
             # Score and rank places
             scored_places = []
             for place in all_places:
+                # Skip permanently closed places always
+                if place.get('business_status') == 'CLOSED_PERMANENTLY':
+                    continue
+
+                # Skip currently closed places if open_now filter is enabled
+                if preferences.get('open_now'):
+                    opening_hours = place.get('opening_hours', {})
+                    if opening_hours.get('open_now') == False:
+                        continue
+
                 score = calculate_score(place, preferences, lat, lng, radius_meters)
 
                 # Calculate distance from start point

--- a/index.html
+++ b/index.html
@@ -116,6 +116,7 @@
                 <span class="icon">🥾</span>
                 <span>Trail Runner</span>
               </button>
+              <button class="preference-chip" data-pref="open_now">⚡ Open Now</button>
             </div>
 
             <!-- Hidden checkboxes for backward compatibility -->
@@ -124,6 +125,7 @@
               <input type="checkbox" id="pref-water">
               <input type="checkbox" id="pref-urban">
               <input type="checkbox" id="pref-trail">
+              <input type="checkbox" id="pref-open-now" class="hidden" />
             </div>
           </div>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ const prefParks = document.getElementById('pref-parks') as HTMLInputElement;
 const prefWater = document.getElementById('pref-water') as HTMLInputElement;
 const prefUrban = document.getElementById('pref-urban') as HTMLInputElement;
 const prefTrail = document.getElementById('pref-trail') as HTMLInputElement;
+const prefOpenNow = document.getElementById('pref-open-now') as HTMLInputElement;
 const findPlacesBtn = document.getElementById('find-places-btn') as HTMLButtonElement;
 const mapSection = document.getElementById('map-section') as HTMLDivElement;
 const placesSection = document.getElementById('places-section') as HTMLDivElement;
@@ -129,6 +130,7 @@ function getPreferences(): Preferences {
     water_stops: prefWater.checked,
     urban_explorer: prefUrban.checked,
     trail_runner: prefTrail.checked,
+    open_now: prefOpenNow.checked,
   };
 }
 
@@ -269,6 +271,7 @@ document.querySelectorAll('.preference-chip').forEach(chip => {
     if (pref === 'water') prefWater.checked = chip.classList.contains('active');
     if (pref === 'urban') prefUrban.checked = chip.classList.contains('active');
     if (pref === 'trail') prefTrail.checked = chip.classList.contains('active');
+    if (pref === 'open_now') prefOpenNow.checked = chip.classList.contains('active');
   });
 });
 
@@ -646,6 +649,7 @@ startOverBtn.addEventListener('click', () => {
   prefParks.checked = false;
   prefWater.checked = false;
   prefUrban.checked = false;
+  prefOpenNow.checked = false;
 
   state.location = null;
   state.distance = 5;

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,7 @@ export interface Preferences {
   water_stops?: boolean;
   urban_explorer?: boolean;
   trail_runner?: boolean;
+  open_now?: boolean;
 }
 
 export interface SuggestPlacesRequest {


### PR DESCRIPTION
## Summary
- New 'Open Now' preference chip in the UI
- When enabled, fully excludes places where opening_hours.open_now == false
- Backend filter in suggest-places.py (no extra API calls)
- Complements issue #2's soft 0.2x penalty with a hard exclude toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)