### PR TITLE
feat: km/mi units toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,8 +11,16 @@
     <!-- Hero Section -->
     <header class="bg-gradient-to-br from-blue-600 to-blue-700 text-white">
       <div class="max-w-7xl mx-auto px-4 py-8">
-        <h1 class="text-4xl font-bold">Running Maps</h1>
-        <p class="text-blue-100 mt-2 text-lg">Plan your perfect running route through interesting places</p>
+        <div class="flex items-center justify-between">
+          <div>
+            <h1 class="text-4xl font-bold">Running Maps</h1>
+            <p class="text-blue-100 mt-2 text-lg">Plan your perfect running route through interesting places</p>
+          </div>
+          <div class="flex items-center gap-1">
+            <button id="units-mi" class="px-2 py-1 rounded-md font-medium text-xs bg-blue-600 text-white">mi</button>
+            <button id="units-km" class="px-2 py-1 rounded-md font-medium text-xs bg-gray-100 text-gray-600 hover:bg-gray-200">km</button>
+          </div>
+        </div>
       </div>
     </header>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,34 @@ const loading = document.getElementById('loading') as HTMLDivElement;
 const initLoader = document.getElementById('init-loader') as HTMLDivElement;
 const errorMessage = document.getElementById('error-message') as HTMLDivElement;
 const progressNav = document.getElementById('progress-nav') as HTMLElement;
+const unitsMiBtn = document.getElementById('units-mi') as HTMLButtonElement;
+const unitsKmBtn = document.getElementById('units-km') as HTMLButtonElement;
+
+// Unit helpers
+type DistanceUnit = 'mi' | 'km';
+
+function getUnit(): DistanceUnit {
+  return (localStorage.getItem('distance_unit') as DistanceUnit) || 'mi';
+}
+
+function setUnit(unit: DistanceUnit): void {
+  localStorage.setItem('distance_unit', unit);
+  updateUnitButtons();
+  if (state.suggestedPlaces.length > 0) displayPlaces();
+  if (state.generatedRoute) displayRouteSummary();
+}
+
+function updateUnitButtons(): void {
+  const unit = getUnit();
+  unitsMiBtn.className = `px-2 py-1 rounded-md font-medium text-xs ${unit === 'mi' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`;
+  unitsKmBtn.className = `px-2 py-1 rounded-md font-medium text-xs ${unit === 'km' ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-600 hover:bg-gray-200'}`;
+}
+
+function formatDistance(miles: number): string {
+  const unit = getUnit();
+  if (unit === 'km') return `${(miles * 1.60934).toFixed(1)} km`;
+  return `${miles.toFixed(1)} mi`;
+}
 
 // Helper functions
 function showLoading(): void {
@@ -272,6 +300,11 @@ document.querySelectorAll('.preference-chip').forEach(chip => {
   });
 });
 
+// Unit toggle handlers
+unitsMiBtn.addEventListener('click', () => setUnit('mi'));
+unitsKmBtn.addEventListener('click', () => setUnit('km'));
+updateUnitButtons(); // init on load
+
 // Map size toggle handler
 if (toggleMapSizeBtn) {
   toggleMapSizeBtn.addEventListener('click', () => {
@@ -436,7 +469,7 @@ function createPlaceCard(place: Place, selected: boolean): HTMLElement {
             </span>
           ` : ''}
           <span class="flex items-center gap-1">
-            📍 ${place.distance_from_start.toFixed(1)} mi
+            📍 ${formatDistance(place.distance_from_start)}
           </span>
         </div>
 
@@ -497,7 +530,7 @@ function updateSelectionInfo(): void {
 
   // Rough estimate: (number of places * average spacing) + connections
   const estimatedMiles = state.distance;
-  estimatedDistance.textContent = `~${estimatedMiles.toFixed(1)} miles`;
+  estimatedDistance.textContent = `~${formatDistance(estimatedMiles)}`;
 
   generateRouteBtn.disabled = count === 0;
 }
@@ -569,7 +602,7 @@ function displayRouteSummary(): void {
 
   routeSummary.innerHTML = `
     <p class="text-lg mb-2">
-      <strong>${distance_miles} mile${distance_miles !== 1 ? 's' : ''}</strong>
+      <strong>${formatDistance(distance_miles)}</strong>
       visiting ${optimized_order.length} place${optimized_order.length !== 1 ? 's' : ''}
     </p>
     <p class="text-gray-600 mb-2">${placeNames}</p>


### PR DESCRIPTION
## Summary
- mi/km toggle button in the UI header
- All displayed distances (place cards, route summary, selection info) convert to selected unit
- Persists in localStorage across sessions
- Backend stays in miles — pure frontend conversion via formatDistance()

🤖 Generated with [Claude Code](https://claude.com/claude-code)