### PR TITLE
feat: quick-select preset buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,16 @@
         <!-- Places List -->
         <div id="places-section" class="bg-white rounded-lg shadow-md p-6 mb-4">
           <h2 class="text-xl font-semibold mb-4">Select Places to Visit</h2>
-          <p class="text-sm text-gray-600 mb-4">
-            <span id="selection-count">3 places selected</span> -
-            <span id="estimated-distance">~5.0 miles</span>
-          </p>
+          <div class="flex items-center gap-2 flex-wrap mb-4">
+            <span id="selection-count" class="text-sm text-gray-600">3 places selected</span>
+            <span class="text-gray-300">·</span>
+            <span id="estimated-distance" class="text-sm text-gray-600">~5.0 miles</span>
+            <div class="flex gap-1 ml-2">
+              <button id="quick-top3" class="text-xs text-blue-600 hover:text-blue-800 font-medium px-2 py-1 hover:bg-blue-50 rounded transition-colors">Top 3</button>
+              <button id="quick-parks" class="text-xs text-green-600 hover:text-green-800 font-medium px-2 py-1 hover:bg-green-50 rounded transition-colors">All Parks</button>
+              <button id="quick-clear" class="text-xs text-gray-500 hover:text-gray-700 font-medium px-2 py-1 hover:bg-gray-100 rounded transition-colors">Clear</button>
+            </div>
+          </div>
           <div id="places-list" class="space-y-3"></div>
           <button id="generate-route-btn" class="btn-primary w-full mt-6">
             Generate Route

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,9 @@ const shareBtn = document.getElementById('share-btn') as HTMLButtonElement;
 const editSelectionsBtn = document.getElementById('edit-selections-btn') as HTMLButtonElement;
 const startOverBtn = document.getElementById('start-over-btn') as HTMLButtonElement;
 const toggleMapSizeBtn = document.getElementById('toggle-map-size') as HTMLButtonElement;
+const quickTop3Btn = document.getElementById('quick-top3') as HTMLButtonElement;
+const quickParksBtn = document.getElementById('quick-parks') as HTMLButtonElement;
+const quickClearBtn = document.getElementById('quick-clear') as HTMLButtonElement;
 const loading = document.getElementById('loading') as HTMLDivElement;
 const initLoader = document.getElementById('init-loader') as HTMLDivElement;
 const errorMessage = document.getElementById('error-message') as HTMLDivElement;
@@ -281,6 +284,30 @@ if (toggleMapSizeBtn) {
     }
   });
 }
+
+// Quick-select handlers
+quickTop3Btn.addEventListener('click', () => {
+  state.selectedPlaceIds = new Set(state.suggestedPlaces.slice(0, 3).map(p => p.id));
+  displayPlaces();
+  updateSelectionInfo();
+});
+
+quickParksBtn.addEventListener('click', () => {
+  const parkIds = state.suggestedPlaces
+    .filter(p => p.types.some(t => ['park', 'natural_feature', 'hiking_area', 'nature_preserve'].includes(t)))
+    .map(p => p.id);
+  if (parkIds.length > 0) {
+    state.selectedPlaceIds = new Set(parkIds);
+    displayPlaces();
+    updateSelectionInfo();
+  }
+});
+
+quickClearBtn.addEventListener('click', () => {
+  state.selectedPlaceIds.clear();
+  displayPlaces();
+  updateSelectionInfo();
+});
 
 // Distance select handler
 distanceSelect.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- 'Top 3': selects the 3 highest-scored places instantly
- 'All Parks': selects all nature/park type places
- 'Clear': deselects everything
- Ghost-style buttons inline with selection counter

Closes #50
🤖 Generated with [Claude Code](https://claude.com/claude-code)