### PR TITLE
fix: migrate to PlaceAutocompleteElement for new Google Maps API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ venv/
 .DS_Store
 Thumbs.db
 .vercel
+.env*.local

--- a/src/google-maps-loader.ts
+++ b/src/google-maps-loader.ts
@@ -28,7 +28,7 @@ export function loadGoogleMapsAPI(): Promise<void> {
 
     // Create script element with callback
     const script = document.createElement('script');
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&callback=${callbackName}`;
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${apiKey}&libraries=places&loading=async&callback=${callbackName}`;
     script.async = true;
     script.defer = true;
 

--- a/src/map.ts
+++ b/src/map.ts
@@ -222,45 +222,31 @@ export class RouteMap {
     }
   }
 
-  /**
-   * Create classic Autocomplete widget for an input element
-   * Uses the legacy Places API which works with HTTP referrer restrictions
-   */
   createPlaceAutocomplete(
     inputContainer: HTMLElement,
     onPlaceSelected?: (location: Location) => void
-  ): google.maps.places.Autocomplete {
-    // Create an input element
-    const input = document.createElement('input');
-    input.type = 'text';
-    input.placeholder = 'Search for a city or address...';
-    input.className = 'w-full pl-12 pr-4 py-3 border-2 border-gray-300 rounded-xl focus:border-blue-500 focus:ring-4 focus:ring-blue-500/10 transition-all duration-200';
-
-    // Clear the container and add the input
+  ): void {
     inputContainer.innerHTML = '';
-    inputContainer.appendChild(input);
 
-    // Create the autocomplete widget
-    const autocomplete = new google.maps.places.Autocomplete(input, {
-      fields: ['geometry', 'name'],
+    const placeAutocomplete = new google.maps.places.PlaceAutocompleteElement({
       types: ['geocode', 'establishment'],
-    });
+    } as any);
 
-    // Listen for place selection
+    (placeAutocomplete as HTMLElement).style.width = '100%';
+    inputContainer.appendChild(placeAutocomplete as unknown as HTMLElement);
+
     if (onPlaceSelected) {
-      autocomplete.addListener('place_changed', () => {
-        const place = autocomplete.getPlace();
+      placeAutocomplete.addEventListener('gmp-placeselect', async (event: Event) => {
+        const place = (event as any).place as google.maps.places.Place;
+        await place.fetchFields({ fields: ['location', 'displayName'] });
 
-        if (place.geometry && place.geometry.location) {
-          const location: Location = {
-            lat: place.geometry.location.lat(),
-            lng: place.geometry.location.lng(),
-          };
-          onPlaceSelected(location);
+        if (place.location) {
+          onPlaceSelected({
+            lat: place.location.lat(),
+            lng: place.location.lng(),
+          });
         }
       });
     }
-
-    return autocomplete;
   }
 }


### PR DESCRIPTION
## Summary
- Replaces deprecated `google.maps.places.Autocomplete` with `PlaceAutocompleteElement` — the legacy widget is unavailable to new API key customers (March 2025+), causing address selection to silently fail
- Switches event listener from `place_changed` to `gmp-placeselect` with `place.fetchFields()` for geometry
- Adds `loading=async` to the Maps JS script URL per Google's recommended pattern

## Test plan
- [ ] Navigate to running-maps.vercel.app
- [ ] Type an address in the Starting Location field
- [ ] Confirm suggestions appear and selecting one enables the Find Places button
- [ ] Confirm no "This page can't load Google Maps correctly" error in the dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)