### PR TITLE
fix: render gmp-place-autocomplete correctly

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,17 +47,7 @@
               Starting Location
             </label>
 
-            <div class="relative">
-              <!-- Search icon -->
-              <div class="absolute left-4 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none z-10">
-                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                        d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
-                </svg>
-              </div>
-
-              <div id="location-autocomplete-container" class="w-full"></div>
-            </div>
+            <div id="location-autocomplete-container" class="w-full"></div>
 
             <p class="mt-2 text-xs text-gray-500 flex items-center gap-1">
               <span>💡</span>

--- a/src/styles.css
+++ b/src/styles.css
@@ -100,6 +100,11 @@
   }
 }
 
+gmp-place-autocomplete {
+  display: block;
+  width: 100%;
+}
+
 @media (max-width: 640px) {
   #map {
     height: 50vh !important;


### PR DESCRIPTION
## Summary
- Fixes `gmp-place-autocomplete` rendering as a tiny icon instead of a full input field — the web component defaults to `display: inline`, setting `display: block` in CSS makes it fill the container
- Removes the now-redundant absolutely-positioned search icon overlay since `PlaceAutocompleteElement` renders its own search icon

## Test plan
- [ ] Starting Location field shows a full-width text input
- [ ] Typing an address shows suggestions
- [ ] Selecting a suggestion enables the Find Places button

🤖 Generated with [Claude Code](https://claude.com/claude-code)